### PR TITLE
Do not rate throttling on discovery

### DIFF
--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -212,7 +212,7 @@ def rate_throttling(response):
         time.sleep(seconds_to_sleep)
 
 # pylint: disable=dangerous-default-value
-def authed_get(source, url, headers={}):
+def authed_get(source, url, headers={}, do_rate_throttling=True):
     with metrics.http_request_timer(source) as timer:
         session.headers.update(headers)
         resp = session.request(method='get', url=url)
@@ -221,7 +221,8 @@ def authed_get(source, url, headers={}):
             return None
         else:
             timer.tags[metrics.Tag.http_status_code] = resp.status_code
-            rate_throttling(resp)
+            if do_rate_throttling:
+                rate_throttling(resp)
             return resp
 
 def authed_get_all_pages(source, url, headers={}):
@@ -325,7 +326,7 @@ def get_catalog():
 
 def verify_repo_access(url_for_repo, repo):
     try:
-        authed_get("verifying repository access", url_for_repo)
+        authed_get("verifying repository access", url_for_repo, do_rate_throttling=False)
     except NotFoundException:
         # throwing user-friendly error message as it checks token access
         message = "HTTP-error-code: 404, Error: Please check the repository name \'{}\' or you do not have sufficient permissions to access this repository.".format(repo)

--- a/tests/unittests/test_rate_limit.py
+++ b/tests/unittests/test_rate_limit.py
@@ -78,13 +78,13 @@ class TestRateLimit(unittest.TestCase):
         tap_github.authed_get('verifying repository access', 'https://api.github.com/repos/foo/commits')
         self.assertEqual(1, mocked_rate_throttling.call_count)
 
-        # Throttling should be called by default
+        # Throttling should be called if enabled explicitly
         mocked_rate_throttling.reset_mock()
         tap_github.authed_get('verifying repository access', 'https://api.github.com/repos/foo/commits',
                               do_rate_throttling=True)
         self.assertEqual(1, mocked_rate_throttling.call_count)
 
-        # Throttling should be called by default
+        # Throttling should not be called if it's disabled
         mocked_rate_throttling.reset_mock()
         tap_github.authed_get('verifying repository access', 'https://api.github.com/repos/foo/commits',
                               do_rate_throttling=False)

--- a/tests/unittests/test_rate_limit.py
+++ b/tests/unittests/test_rate_limit.py
@@ -15,7 +15,7 @@ class TestRateLimit(unittest.TestCase):
         importlib.reload(tap_github)
 
 
-    def _test_rate_limit_wait_with_default_max_rate_limit(self, mocked_sleep):
+    def test_rate_limit_wait_with_default_max_rate_limit(self, mocked_sleep):
 
         mocked_sleep.side_effect = None
 
@@ -29,7 +29,7 @@ class TestRateLimit(unittest.TestCase):
         self.assertTrue(mocked_sleep.called)
 
 
-    def _test_rate_limit_exception_when_exceed_default_max_rate_limit(self, mocked_sleep):
+    def test_rate_limit_exception_when_exceed_default_max_rate_limit(self, mocked_sleep):
 
         mocked_sleep.side_effect = None
 
@@ -43,7 +43,7 @@ class TestRateLimit(unittest.TestCase):
             self.assertEqual(str(e), "API rate limit exceeded, please try after 601 seconds.")
 
 
-    def _test_rate_limit_not_exceed_default_max_rate_limit(self, mocked_sleep):
+    def test_rate_limit_not_exceed_default_max_rate_limit(self, mocked_sleep):
 
         mocked_sleep.side_effect = None
 
@@ -55,7 +55,7 @@ class TestRateLimit(unittest.TestCase):
 
         self.assertFalse(mocked_sleep.called)
 
-    def _test_rate_limit_config_override_throw_exception(self, mocked_sleep):
+    def test_rate_limit_config_override_throw_exception(self, mocked_sleep):
         tap_github.MAX_RATE_LIMIT_WAIT_SECONDS = 1
 
         resp = api_call()


### PR DESCRIPTION
## Problem

Rate throttling is fine but we should not wait when doing discovery.

## Proposed changes

Make rate throttling optional on `authed_get` function that used during the discovery and normal run. Do throttling by default but disable it when doing discovery.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
