### PR TITLE
Lock test requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,8 @@ setup(name='pipelinewise-tap-github',
       ],
       extras_require={
           'test': [
-              'pylint',
-              'pytest',
-              'ipdb',
-              'nose',
+              'pylint==2.10.2',
+              'pytest==6.2.4'
           ]
       },
       entry_points='''
@@ -34,7 +32,7 @@ setup(name='pipelinewise-tap-github',
           tap-github=tap_github:main
       ''',
       packages=['tap_github'],
-      package_data = {
+      package_data={
           'tap_github': ['tap_github/schemas/*.json']
       },
       include_package_data=True

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -269,7 +269,7 @@ def load_schemas():
     for filename in os.listdir(get_abs_path('schemas')):
         path = get_abs_path('schemas') + '/' + filename
         file_raw = filename.replace('.json', '')
-        with open(path) as file:
+        with open(path, encoding='utf-8') as file:
             schemas[file_raw] = json.load(file)
 
     schemas['pr_commits'] = generate_pr_commit_schema(schemas['commits'])


### PR DESCRIPTION
## Problem

Linter is currently failing because `unspecified-encoding (W1514)` pylint check was introduced very recently.

## Proposed changes

Lock test requirements to fix versions and remove not required ones.

Using the automatically the latest version makes the packaged python code not reproducable and better to lock at least the major and minor versions. On the other hand the affected requirements are only test requirements so if we prefer we can leave it as is, pointing always to the latest.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
