### PR TITLE
Add verify_all_repo_access config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ include_archived            |no         |true/false to include archived repos. D
 include_disabled            |no         |true/false to include disabled repos. Default false 
 repository                  |no         |(DEPRECATED) Allow list strategy to extract selected repos data from organization(has priority over repos_exclude) 
 max_rate_limit_wait_seconds |no         |Max time to wait if you hit the github api limit. DEFAULT to 600s
+verify_all_repo_access      |no         |Verify access to all selected repositories. If it's false then it verifies access only to the first selected repository. Default true
 
 Example:
 ```json
@@ -70,7 +71,8 @@ Example:
   "start_date": "2021-01-01T00:00:00Z",
   "include_archived": false,
   "include_disabled": false,
-  "max_rate_limit_wait_seconds": 800
+  "max_rate_limit_wait_seconds": 800,
+  "verify_all_repo_access": true
 }
 ```
 

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -349,6 +349,8 @@ def verify_access_for_repo(config):
     session.headers.update({'authorization': 'token ' + access_token, 'per_page': '1', 'page': '1'})
 
     repositories = get_repos_from_config(config)
+    if not config.get('verify_all_repo_access', True) and len(repositories) > 0:
+        repositories = [repositories[0]]
 
     for repo in repositories:
         logger.info("Verifying access of repository: %s", repo)

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -349,10 +349,16 @@ def verify_access_for_repo(config):
     session.headers.update({'authorization': 'token ' + access_token, 'per_page': '1', 'page': '1'})
 
     repositories = get_repos_from_config(config)
-    if not config.get('verify_all_repo_access', True) and len(repositories) > 0:
-        repositories = [repositories[0]]
+    verify_all = config.get('verify_all_repo_access', True)
 
-    for repo in repositories:
+    if verify_all and len(repositories) > 0:
+        repos_to_verify = repositories
+    elif len(repositories) > 0:
+        repos_to_verify = [repositories[0]]
+    else:
+        repos_to_verify = []
+
+    for repo in repos_to_verify:
         logger.info("Verifying access of repository: %s", repo)
 
         url_for_repo = "https://api.github.com/repos/{}/commits".format(repo)

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -124,3 +124,26 @@ class TestRepoCallCount(unittest.TestCase):
 
         self.assertEqual(mocked_logger_info.call_count, 3)
         self.assertEqual(mocked_repo.call_count, 3)
+
+    def test_verify_repo_access_call_count(self, mocked_repo, mocked_logger_info):
+        mocked_repo.return_value = None
+
+        # Should verify all repository access by default
+        tap_github.verify_access_for_repo({"access_token": "access_token",
+                                           "repository": "org1/repo1 org1/repo2 org2/repo1"})
+        self.assertEqual(mocked_repo.call_count, 3)
+
+        # Should verify all repository access if verify_all_repo_access is False
+        mocked_repo.reset_mock()
+        tap_github.verify_access_for_repo({"access_token": "access_token",
+                                           "repository": "org1/repo1 org1/repo2 org2/repo1",
+                                           "verify_all_repo_access": False})
+        self.assertEqual(mocked_repo.call_count, 1)
+
+        # Should verify all repository access if verify_all_repo_access is True
+        mocked_repo.reset_mock()
+        tap_github.verify_access_for_repo({"access_token": "access_token",
+                                           "repository": "org1/repo1 org1/repo2 org2/repo1",
+                                           "verify_all_repo_access": True})
+        self.assertEqual(mocked_repo.call_count, 3)
+

--- a/tests/unittests/test_verify_access.py
+++ b/tests/unittests/test_verify_access.py
@@ -128,19 +128,19 @@ class TestRepoCallCount(unittest.TestCase):
     def test_verify_repo_access_call_count(self, mocked_repo, mocked_logger_info):
         mocked_repo.return_value = None
 
-        # Should verify all repository access by default
+        # Should verify all repository accesses by default
         tap_github.verify_access_for_repo({"access_token": "access_token",
                                            "repository": "org1/repo1 org1/repo2 org2/repo1"})
         self.assertEqual(mocked_repo.call_count, 3)
 
-        # Should verify all repository access if verify_all_repo_access is False
+        # Should verify only one repository access if verify_all_repo_access is False
         mocked_repo.reset_mock()
         tap_github.verify_access_for_repo({"access_token": "access_token",
                                            "repository": "org1/repo1 org1/repo2 org2/repo1",
                                            "verify_all_repo_access": False})
         self.assertEqual(mocked_repo.call_count, 1)
 
-        # Should verify all repository access if verify_all_repo_access is True
+        # Should verify all repository accesses if verify_all_repo_access is True
         mocked_repo.reset_mock()
         tap_github.verify_access_for_repo({"access_token": "access_token",
                                            "repository": "org1/repo1 org1/repo2 org2/repo1",


### PR DESCRIPTION
## Problem

If lot of repositories selected then verifying access to all of them takes lot of time in discovery mode. In case of 2000 repositories it takes more than 10 minutes, consumes calls from API rate limit and not allowing to deploy new config changes quickly in parallel.

## Proposed changes

Introducing `verify_all_repo_access` configurable parameter that defaults to `True`. It it' `False` then it verifies only one repository access from the selected list and not all of them. If no access to a certain repository then the tap will fail at sync time and not at discovery time making the discovery and config-import time much quicker.

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
