### PR TITLE
Use well formatted github token in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ max_rate_limit_wait_seconds |no         |Max time to wait if you hit the github 
 Example:
 ```json
 {
-  "access_token": "<GITHUB_ACCESS_TOKEN>",
+  "access_token": "ghp_16C7e42F292c6912E7710c838347Ae178B4a",
   "organization": "singer-io", 
   "repos_exclude": "*tests* api-docs",
   "repos_include": "tap* getting-started pipelinewise-github",


### PR DESCRIPTION
## Problem

The `access_token` in README is fully masked and difficult to understand what type of access token is required.

## Proposed changes

Use an invalid but well formatted github personal access token in README. The same one that's available in github API docs.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
