### PR TITLE
add additional field merge_commit_sha to pull requests which is a rea…

### DIFF
--- a/tap_github/schemas/pull_requests.json
+++ b/tap_github/schemas/pull_requests.json
@@ -92,6 +92,9 @@
         }
       }
     },
+    "merge_commit_sha": {
+      "type": ["null", "string"],
+    },
     "merged_at": {
       "type": ["null", "string"],
       "format": "date-time"


### PR DESCRIPTION
…lly helpful relational link

## Problem

pull_request schema has a really important linking id of the merge commit hash, when the pull request is merged (and later closed). this isn't currently populated, and presumably the field is thrown away from the response.

## Proposed changes

Add the merge_commit_sha field to the necessary schema

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
